### PR TITLE
[Chore] 클래스카드 주소영역 카테고리로 대치

### DIFF
--- a/src/components/common/ClassCard.tsx
+++ b/src/components/common/ClassCard.tsx
@@ -14,10 +14,6 @@ const ClassCard = ({ classItem }: ClassCardProps) => {
   if (classItem.is_best) tags.push('best');
   if (classItem.is_viewed) tags.push('viewed');
 
-  // 타입 가드로 address 타입 확인
-  const addressState = '';
-  const addressCity = '';
-
   const imageUrl =
     classItem.images &&
     classItem.images[0] !== undefined &&
@@ -51,9 +47,7 @@ const ClassCard = ({ classItem }: ClassCardProps) => {
       <div className="w-full">
         {/* location */}
         <div className="text-gray text-sm mb-2">
-          {addressState && addressCity
-            ? `${addressState} > ${addressCity}`
-            : ''}
+          {classItem?.category[0] ? `Class > ` + classItem?.category[0] : `Class > All`}
         </div>
         <h2 className="w-full text-black font-bold text-lg line-clamp-2 ">
           {classItem.title}


### PR DESCRIPTION
## 변경 세부 내용
- 카드 이미지 하단의 주소 경로를 카테고리로 대체 (피그마 내 피드백 사항 반영) 

## 변경 유형
<!-- 해당되는 칸에 '빈칸'대신 'x'를 삽입합니다 -->
- [ ] 버그 수정 (기존 기능에 지장을 주지 않는 변경)
- [x] 새로운 기능 (기존 기능에 지장을 주지 않는 추가 기능)
- [ ] Breaking change (기존 기능에 영향을 미칠 수 있는 변경)
- [ ] 이 변경 사항은 문서 업데이트가 필요합니다.


## 체크리스트
<!-- 모든 항목을 체크해주세요 -->
- [x] PR 하기 전 로컬환경에서 lint, build 검사를 수행하였습니다.
- [x] 새로운 경고를 생성하지 않습니다.
- [x] 정의서 등의 작업문서에서 요구하는 사항을 반영했습니다.
- [ ] Notion 작업일정에 관련 일정을 반영했습니다.
